### PR TITLE
Type attribute jQuery patch

### DIFF
--- a/polyfills/index.coffee
+++ b/polyfills/index.coffee
@@ -1,2 +1,3 @@
+require './jQuery.typeAttribute.patch'
 require './Element.matches.polyfill'
 require './Array.findIndex.polyfill'

--- a/polyfills/jQuery.typeAttribute.patch.js
+++ b/polyfills/jQuery.typeAttribute.patch.js
@@ -4,31 +4,26 @@
 // https://github.com/jquery/jquery/commit/aad235b3251494afe71fd5bb6031e11965af9bdb
 
 if(typeof jQuery == 'function' || typeof $ == 'function') {
-  console.log("is a function")
-  $(document).ready(function() {
-    console.log("is ready")
-    if (/1\.(7|8)\.\d/.test($.fn.jquery)) {
-      console.log("is 1.7.1")
-      jQuery.extend({
-        attrHooks: {
-          type: {
-            set: function( elem, value ) {
-                // Setting the type on a radio button after the value resets the value in IE6-9
-                // Reset value to it's default in case type is set after value
-                // This is for element creation
-              if ( !jQuery.support.radioValue && value === "radio" && jQuery.nodeName(elem, "input") ) {
-              // Reset value to default in case type is set after value during creation
-                var val = elem.value;
-                elem.setAttribute( "type", value );
-                if ( val ) {
-                  elem.value = val;
-                }
-                return value;
+  if (/1\.(7|8)\.\d/.test($.fn.jquery)) {
+    jQuery.extend({
+      attrHooks: {
+        type: {
+          set: function( elem, value ) {
+              // Setting the type on a radio button after the value resets the value in IE6-9
+              // Reset value to it's default in case type is set after value
+              // This is for element creation
+            if ( !jQuery.support.radioValue && value === "radio" && jQuery.nodeName(elem, "input") ) {
+            // Reset value to default in case type is set after value during creation
+              var val = elem.value;
+              elem.setAttribute( "type", value );
+              if ( val ) {
+                elem.value = val;
               }
+              return value;
             }
           }
         }
-      });
-    }
-  })
+      }
+    });
+  }
 }

--- a/polyfills/jQuery.typeAttribute.patch.js
+++ b/polyfills/jQuery.typeAttribute.patch.js
@@ -1,0 +1,34 @@
+// Patch for jQuery that lets 'type' attributes to be set if the browser allows it.
+// ex: <th-button type="standard">name<th-button>
+// This was only relevant for IE 8 and below which we do not support anyhow.
+// https://github.com/jquery/jquery/commit/aad235b3251494afe71fd5bb6031e11965af9bdb
+
+if(typeof jQuery == 'function' || typeof $ == 'function') {
+  console.log("is a function")
+  $(document).ready(function() {
+    console.log("is ready")
+    if (/1\.(7|8)\.\d/.test($.fn.jquery)) {
+      console.log("is 1.7.1")
+      jQuery.extend({
+        attrHooks: {
+          type: {
+            set: function( elem, value ) {
+                // Setting the type on a radio button after the value resets the value in IE6-9
+                // Reset value to it's default in case type is set after value
+                // This is for element creation
+              if ( !jQuery.support.radioValue && value === "radio" && jQuery.nodeName(elem, "input") ) {
+              // Reset value to default in case type is set after value during creation
+                var val = elem.value;
+                elem.setAttribute( "type", value );
+                if ( val ) {
+                  elem.value = val;
+                }
+                return value;
+              }
+            }
+          }
+        }
+      });
+    }
+  })
+}

--- a/themis_components/thButton/examples/2 - JS Action/coffee.coffee
+++ b/themis_components/thButton/examples/2 - JS Action/coffee.coffee
@@ -2,5 +2,4 @@ angular.module('thDemo', ['ThemisComponents'])
   .controller 'TestButtonController', ->
     @action = ->
       alert('Hello!')
-
     return

--- a/themis_components/thInput/examples/1 - simple/html.html
+++ b/themis_components/thInput/examples/1 - simple/html.html
@@ -1,7 +1,8 @@
 <html ng-app="thDemo">
   <body>
     <th-input type="text" name="name" placeholder="Nickname"></th-input>
+    <br>
     <th-input type="file" name="avatar" icon="file" style="width: 400px;"></th-input>
-    </th-input>
   </body>
+
 </html>

--- a/themis_components/thInput/examples/2 - Prefix, Postfix, Label, and Icon/html.html
+++ b/themis_components/thInput/examples/2 - Prefix, Postfix, Label, and Icon/html.html
@@ -1,8 +1,11 @@
 <html ng-app="thDemo">
   <body>
     <th-input type="text" name="amount" prefix="$"></th-input>
+    <br>
     <th-input type="text" name="rate" postfix="/hr"></th-input>
+    <br>
     <th-input type="text" name="client" icon="user"></th-input>
+    <br>
     <th-input type="file" prefix="Using flexbox" postfix="it grows to fit the content"></th-input>
   </body>
 </html>


### PR DESCRIPTION
Patch for jQuery < 1.9.0 (currently: 1.7.1) that lets 'type' attributes be set if the browser allows it.
ex:
```html
 <th-button type="standard">name<th-button> # this currently will throw an error
```
This was only relevant for IE 8 and below which we do not support anyhow.
https://github.com/jquery/jquery/commit/aad235b3251494afe71fd5bb6031e11965af9bdb