### PR TITLE
quick fix for CSS selector problem

### DIFF
--- a/themis_components/thAlert/index.scss
+++ b/themis_components/thAlert/index.scss
@@ -50,7 +50,7 @@
     vertical-align: middle;
     font-size: 18px;
 
-    &.fa-check, &.fa-warning {
+    &.alert-icon {
       color: #fff;
       text-align: center;
       width: 40px;
@@ -64,7 +64,7 @@
       background: $green-5;
     }
 
-    &.fa-times-circle {
+    &.dismiss-icon {
       cursor: pointer;
       line-height: 54px;
       width: 16px;

--- a/themis_components/thAlert/index.scss
+++ b/themis_components/thAlert/index.scss
@@ -50,7 +50,7 @@
     vertical-align: middle;
     font-size: 18px;
 
-    &:not(.fa-times-circle) {
+    &.fa-check, &.fa-warning {
       color: #fff;
       text-align: center;
       width: 40px;

--- a/themis_components/thAlert/thAlertAnchor.template.html
+++ b/themis_components/thAlert/thAlertAnchor.template.html
@@ -2,19 +2,21 @@
   ng-show="alertAnchor.alertMessage.message"
   ng-class="'th-alert th-alert-' + alertAnchor.alertMessage.type"
   >
-
   <i
-    class="fa"
+    class="fa alert-icon"
     ng-class="{ 'fa-check': alertAnchor.alertMessage.type == 'success',
                 'fa-warning': alertAnchor.alertMessage.type == 'error' ||
                               alertAnchor.alertMessage.type == 'warning' }"
     >
   </i>
-
   <p
     ng-bind-html="alertAnchor.alertMessage.message"
     >
     {{alertAnchor.alertMessage.message}}
   </p>
-  <i class="fa fa-times-circle" ng-click="alertAnchor.dismiss()"></i>
+  <i
+    class="fa fa-times-circle dismiss-icon"
+    ng-click="alertAnchor.dismiss()"
+    >
+  </i>
 </div>


### PR DESCRIPTION
There seems to be a problem using the `:not()` selector. Replacing this with a hardcoded call to the specific classes seems to fix this.  